### PR TITLE
Skip whitespace when looking for the function.

### DIFF
--- a/irony-eldoc.el
+++ b/irony-eldoc.el
@@ -208,6 +208,7 @@ inside `condition-case'."
                      close-paren (save-excursion (forward-list) (point)))
                ;; possibly skip across a template bracket
                (progn (when (= (char-before) ?>) (backward-list))
+                      (skip-syntax-backward " ")
                       (thing-at-point 'symbol)))
         (setq bounds (bounds-of-thing-at-point 'symbol)
               thing (buffer-substring-no-properties


### PR DESCRIPTION
It is customary in the GNU style to leave a space between the function name and the open paren. But thing-at-point doesn't like it, i.e. it won't find the name, when there is a space in front of it.
